### PR TITLE
Add GPU Support for GLiNERRecognizer and Validator Module for PII Detection

### DIFF
--- a/validator/gliner_recognizer.py
+++ b/validator/gliner_recognizer.py
@@ -1,12 +1,15 @@
+import torch
 from presidio_analyzer import EntityRecognizer, RecognizerResult
 from gliner import GLiNER
 from .constants import PRESIDIO_TO_GLINER, GLINER_TO_PRESIDIO
 
 
 class GLiNERRecognizer(EntityRecognizer):
-    def __init__(self, supported_entities, model_name):
+    def __init__(self, supported_entities, model_name, use_gpu=True):
         self.model_name = model_name
         self.supported_entities = supported_entities
+        self.use_gpu = use_gpu
+        self.device = self._get_device()
 
         gliner_entities = set()
 
@@ -18,12 +21,28 @@ class GLiNERRecognizer(EntityRecognizer):
 
         super().__init__(supported_entities=supported_entities)
 
+    def _get_device(self):
+        """Determine the device to use for inference"""
+        if self.use_gpu and torch.cuda.is_available():
+            return torch.device("cuda")
+        return torch.device("cpu")
+
     def load(self) -> None:
-        """No loading required as the model is loaded in the constructor"""
+        """Load the model and move it to the appropriate device"""
         self.model = GLiNER.from_pretrained(self.model_name)
+        self.model = self.model.to(self.device)
+        if self.use_gpu and torch.cuda.is_available():
+            self.model.eval()
 
     def analyze(self, text, entities=None, nlp_artifacts=None):
-        results = self.model.predict_entities(text, self.gliner_entities)
+        """Analyze text using GPU-accelerated GLiNER model"""
+        # Ensure model is on correct device
+        if hasattr(self.model, 'device') and self.model.device != self.device:
+            self.model = self.model.to(self.device)
+        
+        # Run inference with gradient disabled for efficiency
+        with torch.no_grad():
+            results = self.model.predict_entities(text, self.gliner_entities)
         return [
             RecognizerResult(
                 entity_type=GLINER_TO_PRESIDIO[entity["label"]],

--- a/validator/main.py
+++ b/validator/main.py
@@ -79,6 +79,7 @@ class GuardrailsPII(Validator):
         get_entity_threshold: Callable = get_entity_threshold,
         on_fail: Optional[Callable] = None,
         use_local: bool = True,
+        use_gpu: bool = True,
         **kwargs,
     ):
         """Validates that the LLM-generated text does not contain Personally Identifiable Information (PII).
@@ -109,6 +110,7 @@ class GuardrailsPII(Validator):
             entities=entities,
             get_entity_threshold=get_entity_threshold,
             use_local=use_local,
+            use_gpu=use_gpu,
             **kwargs,
         )
 
@@ -119,11 +121,13 @@ class GuardrailsPII(Validator):
             self.entities = entities
         self.model_name = model_name
         self.get_entity_threshold = get_entity_threshold
+        self.use_gpu = use_gpu
 
         if self.use_local:
             self.gliner_recognizer = GLiNERRecognizer(
                 supported_entities=self.entities,
                 model_name=model_name,
+                use_gpu=use_gpu,
             )
             registry = RecognizerRegistry()
             registry.load_predefined_recognizers()


### PR DESCRIPTION
This pull request introduces GPU support for the `GLiNERRecognizer` class and updates the `validator` module to allow GPU usage for PII detection. The changes include adding a `use_gpu` parameter, determining the device for model inference, and ensuring the model is loaded and executed on the appropriate device.

### GPU Support for `GLiNERRecognizer`:

* Added a `use_gpu` parameter to the `GLiNERRecognizer` constructor to enable or disable GPU usage. The `_get_device` method determines whether to use a GPU or CPU based on availability and the `use_gpu` flag. (`validator/gliner_recognizer.py`, [[1]](diffhunk://#diff-b4c9f7a0179d43661cc756d45c1e9c2b0b7db1ebb88fa7467bf5e361eb619befR1-R12) [[2]](diffhunk://#diff-b4c9f7a0179d43661cc756d45c1e9c2b0b7db1ebb88fa7467bf5e361eb619befR24-R44)
* Updated the `load` method to move the model to the appropriate device and set it to evaluation mode if GPU is used. (`validator/gliner_recognizer.py`, [validator/gliner_recognizer.pyR24-R44](diffhunk://#diff-b4c9f7a0179d43661cc756d45c1e9c2b0b7db1ebb88fa7467bf5e361eb619befR24-R44))
* Modified the `analyze` method to ensure the model is on the correct device and to disable gradients during inference for efficiency. (`validator/gliner_recognizer.py`, [validator/gliner_recognizer.pyR24-R44](diffhunk://#diff-b4c9f7a0179d43661cc756d45c1e9c2b0b7db1ebb88fa7467bf5e361eb619befR24-R44))

### Integration with `validator` Module:

* Added a `use_gpu` parameter to the `Validator` class constructor and passed it to the `GLiNERRecognizer` instance when `use_local` is enabled. (`validator/main.py`, [[1]](diffhunk://#diff-540acc59a982bc0e65b93e7f059f2ee471c0885170a4666217d8ad2e1743227dR82) [[2]](diffhunk://#diff-540acc59a982bc0e65b93e7f059f2ee471c0885170a4666217d8ad2e1743227dR113) [[3]](diffhunk://#diff-540acc59a982bc0e65b93e7f059f2ee471c0885170a4666217d8ad2e1743227dR124-R130)